### PR TITLE
Keeping Jimmy Handsome in IE

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,8 +238,8 @@
     }
 
     .keynote .speaker-image {
-      max-height: initial;
-      max-width: initial;
+      max-height: 100%;
+      max-width: 100%;
     }
 
     .keynote h2 {
@@ -258,7 +258,7 @@
 
     .keynote .speaker-image img {
       max-width: 100%;
-      max-height: initial;
+      max-height: 100%;
     }
     .sponsor-image {
       position: relative;


### PR DESCRIPTION
IE doesn't understand the CSS initial value and as such was making the
keynote speaker image distort at many browser sizes.

Even though Jimmy looks good from any angle I changed the CSS to work
everywhere (I was able to test that is).

Tested change on Windows 7 machine with the following browsers:

IE 10.0.9200.17267, IE 11.0.9600.17691, Chrome 41.0.2272.101, FireFox
33.0.3, Opera 12.17, Safari 5.1.5

Additionally, I tested on:

Safari 8.0.3 on OS X 10.10.2
iPad 2 running iOS 7.0.3
HTC 8X Win Phone 8.1 mobile and desktop mode

Jimmy's handsome factor has been well preserved on IE now. :-)
