### PR TITLE
Add proposal template back and fix code of conduct link

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -6,7 +6,7 @@ Speaker proposals are handled through GitHub pull requests. Follow the instructi
 
 * Create a **GitHub account** if you don't have one already.
 * **Fork this repository**.
-* Review the **[Code of Conduct](https://github.com/dotnetfringe/dotnetfringe.github.io/blob/master/code-of-conduct.md)**.
+* Review the **[Code of Conduct](https://github.com/dotnetfringe/dotnetfringe.github.io/blob/master/docs/code-of-conduct.md)**.
 * **Create and commit a .MD file** in this directory named after the talk title and your name. For example, if your talk is called "Intro To aspnet5 and CQRS" and your name is Jane Doe, name the file **intro-to-aspnet5-and-cqrs_jane-doe.md**.
 * When you're ready, **submit a pull request**.
 * **Wait patiently** and nicely for us to contact you. We will respond to everyone who submits a proposal even if it's just to say "Thanks but no thanks".

--- a/proposals/proposal-template_jane-doe.md
+++ b/proposals/proposal-template_jane-doe.md
@@ -1,0 +1,26 @@
+[Proposal Title]
+========================
+
+* Speaker   : [Your Name, eg: *Jane Doe*]
+* Available : [Dates/Times Available, eg: *July 11th, 9am-12pm*] 
+* Length    : [Length of Presentation, eg: *30 mins*]
+
+Description
+-----------
+
+[Presentation description goes here. Try to keep it under say, 500 words, but more than 140 characters]
+
+---------------
+[*All things below are optional*]
+
+Speaker Bio
+-----------
+
+I work for big-corp doing big-corpy stuff and massive distributed systems. I also am known for creating magical unicorn libraries that distribute rainbows on a multi-regional fully distributed global scale to prevent rainbow deprivation!
+
+Links
+-----
+
+* Blog: http://writehereido.me/stuff-i-do
+* Company: http://big-corp.com/the-corpy-products
+* Github: http://github.com/jane-doe


### PR DESCRIPTION
The template was modified in a previous proposal and renamed. It has
been restored.

The code of conduct in the README linked to a page which does not exist.
It has been updated to its current location.
