### PR TITLE
Fixes paths for code of conduct

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
     <footer>
       <div class="container">
         <div class="copy">
-          <p>&copy; .NET Fringe 2016 - <a href="docs/code-of-conduct.html">Code Of Conduct</a> - Previous: <a href="http://2015.dotnetfringe.org">2015</a> | Template by <a href="http://w3layouts.com" target="_blank"> w3layouts</a></p>
+          <p>&copy; .NET Fringe 2016 - <a href="code-of-conduct.html">Code Of Conduct</a> - Previous: <a href="http://2015.dotnetfringe.org">2015</a> | Template by <a href="http://w3layouts.com" target="_blank"> w3layouts</a></p>
         </div>
         <div class="social">
           <ul>

--- a/docs/template.sh
+++ b/docs/template.sh
@@ -124,7 +124,7 @@ cat << _EOF_
     <footer>
       <div class="container">
         <div class="copy">
-          <p>&copy; .NET Fringe 2016 - <a href="docs/code-of-conduct.html">Code Of Conduct</a> - Previous: <a href="http://2015.dotnetfringe.org">2015</a> | Template by <a href="http://w3layouts.com" target="_blank"> w3layouts</a></p>
+          <p>&copy; .NET Fringe 2016 - <a href="code-of-conduct.html">Code Of Conduct</a> - Previous: <a href="http://2015.dotnetfringe.org">2015</a> | Template by <a href="http://w3layouts.com" target="_blank"> w3layouts</a></p>
         </div>
         <div class="social">
           <ul>


### PR DESCRIPTION
While browsing the .NET Fringe site I noticed that the code of conduct link 404ed in some cases.
